### PR TITLE
stop gcc from generating `endbr32` instruction

### DIFF
--- a/compilerex/compilerex.py
+++ b/compilerex/compilerex.py
@@ -32,7 +32,7 @@ assemble = clang_assemble
 def gcc_assemble(args):
     if not isinstance(args, list):
         args = [args]
-    p = subprocess.Popen(["gcc", "-fno-stack-protector", "-no-pie",] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(["gcc", "-fcf-protection=none", "-fno-stack-protector", "-no-pie",] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     res = p.communicate()
     returncode = p.wait()
     return returncode, res


### PR DESCRIPTION
Ubuntu 20 starts to use gcc-9 by default, which generates `endbr32` instructions that clang does not support.
So I've added the `-fcf-protection=none` option to prevent gcc from generating "endbr32" instructions.

This should fix `test_backdoor` `test_bitflip` and `test_transmitprotection` in
https://github.com/angr/archinfo/runs/6480224914

More information about `-fcf-protection`
https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html